### PR TITLE
Fix the Singleton algorithm

### DIFF
--- a/UnaCloudWeb/src/java/uniandes/unacloud/web/pmallocators/SingletonAllocator.java
+++ b/UnaCloudWeb/src/java/uniandes/unacloud/web/pmallocators/SingletonAllocator.java
@@ -20,24 +20,56 @@ public class SingletonAllocator extends ExecutionAllocator {
 	@Override
 	protected void allocateExecutions(List<Execution> executionList, List<PhysicalMachine> physicalMachines, 
 			Map<Long, PhysicalMachineAllocationDescription> physicalMachineDescriptions) throws AllocatorException {
-		for (PhysicalMachine pm : physicalMachines) {
+		
+		// start with the first physical machine and the first virtual machine
+		int nextPm = 0;
+		int nextVm = 0;
+
+		// while there are physical and virtual machines
+		while (nextPm < physicalMachines.size() && nextVm < executionList.size()) {
+						
+			// get the physical and virtual machines
+			PhysicalMachine pm = physicalMachines.get(nextPm);
+			Execution vm = executionList.get(nextVm);
+			
+			// get the machine description
 			PhysicalMachineAllocationDescription pmad = physicalMachineDescriptions.get(pm.getDatabaseId());
 			if (pmad == null) {
-				for (Execution vm : executionList) {
-					if (fitEXonPM(vm, pm, pmad)) {
-						vm.setExecutionNode(pm);
-						if (pmad == null) {
-							pmad = new PhysicalMachineAllocationDescription(pm.getDatabaseId(), 0, 0, 0);
-							physicalMachineDescriptions.put(pmad.getNodeId(), pmad);
-						}
-						pmad.addResources(vm.getHardwareProfile().getCores(), vm.getHardwareProfile().getRam(), 1);
+				
+				// if the physical machine can run the vm
+				if (fitEXonPM(vm, pm, pmad)) {
+						
+					// assign the vm to the virtual machine
+					vm.setExecutionNode(pm);
+					if (pmad == null) {
+						pmad = new PhysicalMachineAllocationDescription(pm.getDatabaseId(), 0, 0, 0);
+						physicalMachineDescriptions.put(pmad.getNodeId(), pmad);
 					}
-					else throw new AllocatorException("Cannot allocate all Executions on a single machine");	
-				}
-				break;
+					// increase the resources used in that machine
+					pmad.addResources(vm.getHardwareProfile().getCores(), vm.getHardwareProfile().getRam(), 1);
+					
+					// get the next VM
+					nextVm++;
+					// use the next PM
+					nextPm++;
+				
+				// if the physical machine cannot run the vm
+				} else {
+					// try the next PM
+					nextPm++;
+				}				
 			}
-			
 		}
+		
+		// ends the cycle when:
+		//   all the VMs have been allocated
+		//   all the PMs have been tested
+		
+		// is there a non-allocated VM ?
+		if (nextVm < executionList.size()) {
+			throw new AllocatorException("Cannot allocate all Executions on separated machines");
+		}
+		
 	}
 
 }


### PR DESCRIPTION
The existing algorithm throws an error when some physical machine cannot allocate the next virtual machine. It did not reviewed if that virtual machine can be allocated in another physical machine.